### PR TITLE
PHP 7.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ mediawiki/oauthclient
 =====================
 
 PHP [OAuth][] client for use with [Wikipedia][] and other MediaWiki-based
-wikis running the [OAuth extension][].
+wikis running the [OAuth extension][]. It is not compatible with PHP 7.4.
 
 
 Installation


### PR DESCRIPTION
PHP Deprecated:  Array and string offset access syntax with curly braces is deprecated in ./vendor/mediawiki/oauthclient/src/Client.php on line 414.

Or some one smarter than me could fix it